### PR TITLE
Fix: Remove designated initializer from pybind11::buffer_info

### DIFF
--- a/vulkpy/_vkarray.cc
+++ b/vulkpy/_vkarray.cc
@@ -793,12 +793,12 @@ PYBIND11_MODULE(_vkarray, m){
     .def("size", &Buffer<float>::size)
     .def_buffer([](Buffer<float>& m) {
       return pybind11::buffer_info {
-        .ptr=m.data(),
-        .itemsize=sizeof(float),
-        .format=pybind11::format_descriptor<float>::format(),
-        .ndim=1,
-        .shape={ m.size() },
-        .strides={ sizeof(float) }
+        /* .ptr=      */ m.data(),
+        /* .itemsize= */ sizeof(float),
+        /* .format=   */ pybind11::format_descriptor<float>::format(),
+        /* .ndim=     */ 1,
+        /* .shape=    */ { m.size() },
+        /* .strides=  */ { sizeof(float) }
       };
     });
 
@@ -812,12 +812,12 @@ PYBIND11_MODULE(_vkarray, m){
     .def("size", &Buffer<std::uint32_t>::size)
     .def_buffer([](Buffer<std::uint32_t>& m) {
       return pybind11::buffer_info {
-        .ptr=m.data(),
-        .itemsize=sizeof(std::uint32_t),
-        .format=pybind11::format_descriptor<std::uint32_t>::format(),
-        .ndim=1,
-        .shape={ m.size() },
-        .strides={ sizeof(std::uint32_t) }
+        /* .ptr=      */ m.data(),
+        /* .itemsize= */ sizeof(std::uint32_t),
+        /* .format=   */ pybind11::format_descriptor<std::uint32_t>::format(),
+        /* .ndim=     */ 1,
+        /* .shape=    */ { m.size() },
+        /* .strides=  */ { sizeof(std::uint32_t) }
       };
     });
 


### PR DESCRIPTION
Some version of gcc failed to compile wheel because of designated initializer at `pybind11::buffer_info`. [1]

Until C++20, class with user-provided or explicit constructor is not treated as aggregate type [2], and `pybind11::buffer_info` has such constructors. [3]

Algouth we specify C++20 by `-std=c++2a` compiler option, some compiler might not fully support C++20.

We remove designated initializer and use normal constructor.

[1] https://github.com/ymd-h/vulkpy/issues/3
[2] https://en.cppreference.com/w/cpp/language/aggregate_initialization
[3] https://github.com/pybind/pybind11/blob/v2.10.3/include/pybind11/buffer_info.h#L57-L122